### PR TITLE
Mayapy create sitecustomize

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,8 +28,10 @@
         "Mobu",
         "Mobupy",
         "motionbuilder",
+        "ngskintools",
         "onefile",
         "pipx",
+        "PROGRAMDATA",
         "pydantic",
         "pydocstyle",
         "pyinstaller",
@@ -37,6 +39,7 @@
         "pytest",
         "PYTHONUNBUFFERED",
         "SCRIPTPLUGINS",
+        "sitecustomize",
         "sitepackages",
         "venv",
         "Wilhelmsen"

--- a/src/devin/cli/base.py
+++ b/src/devin/cli/base.py
@@ -10,6 +10,7 @@ import logging
 import logging.config
 import os
 import sys
+from distutils.sysconfig import get_python_lib
 from pathlib import Path
 from typing import Literal
 
@@ -110,7 +111,7 @@ class BaseDCCCommand(BaseCommand):
     def _computed_site_path(self) -> str | None:
         site_dirs: list[Path] = []
         if self.include_prefix_site:
-            site_dirs = [(Path(sys.prefix) / "Lib" / "site-packages")]
+            site_dirs = [Path(get_python_lib(prefix=sys.prefix))]
 
         if self.site_path:
             site_dirs.extend(self.site_path)

--- a/src/devin/cli/maya.py
+++ b/src/devin/cli/maya.py
@@ -8,8 +8,11 @@
 
 import logging
 import os
+import sys
+from distutils.sysconfig import get_python_lib
 from functools import cached_property
-from subprocess import call
+from pathlib import Path
+from subprocess import call, check_output
 from typing import Literal
 
 from pydantic import (
@@ -19,6 +22,7 @@ from pydantic import (
     FilePath,
     computed_field,
 )
+from pydantic_settings import CliImplicitFlag
 
 from devin.cli.base import BaseDCCCommand
 from devin.constants import DATA_DIR
@@ -72,7 +76,7 @@ class MayaBaseCommand(BaseDCCCommand):
         # Set up Maya plugin path
         if self.plugin_path:
             env["MAYA_PLUG_IN_PATH"] = ";".join(
-                [x.as_posix() for x in self.plugin_path]
+                [x.as_posix() for x in self.plugin_path],
             )
 
         # Set up Maya module path
@@ -129,7 +133,7 @@ class Maya(MayaBaseCommand):
         """Run Maya with computed arguments and env."""
         self.configure_logging()
         args = [self._computed_executable.as_posix(), *self.args]
-        call(
+        _ = call(
             args=args,
             env=self.env,
         )
@@ -143,6 +147,59 @@ class Mayapy(MayaBaseCommand):
         validation_alias=AliasChoices("executable", "exe"),
         description="Path to mayapy executable",
     )
+
+    create_prefix_sitecustomize: CliImplicitFlag[bool] = Field(
+        default=False,
+        description=(
+            "Create a sitecustomize.py file pointing "
+            "to mayapy's site packages dir in prefix site-packages and exit."
+        ),
+    )
+
+    def create_sitecustomize(self) -> None:
+        """Create a sitecustomize.py file in prefix site-packages dir."""
+        # get site-packages from mayapy
+        args = [
+            self._computed_executable.as_posix(),
+            "-c",
+            "from site import getsitepackages;[print(x) for x in getsitepackages()]",
+        ]
+        sitepackages = check_output(args=args, encoding="utf-8").splitlines()
+
+        # get ngSkinTools from ApplicationPlugins dir
+        ng_skin_tools_paths = [
+            Path.home() / "Autodesk/ApplicationPlugins/ngskintools2",
+            Path("/usr/autodesk/ApplicationPlugins/ngskintools2"),
+            Path(os.getenv("PROGRAMDATA", default=""))
+            / "Autodesk/ApplicationPlugins/ngskintools2",
+        ]
+
+        # Add the first ngSkinTools plugin dir that exists to sitepackages
+        for p in ng_skin_tools_paths:
+            if p.is_dir():
+                sitepackages.append(p.as_posix())
+                break
+
+        # Create the sitecustomize.py file
+        sitecustomize_data = "\n".join(
+            [
+                "import site",
+                *[f"site.addsitedir('{x}')" for x in sitepackages],
+            ],
+        )
+
+        sitecustomize = Path(get_python_lib(prefix=sys.prefix)) / "sitecustomize.py"
+        if not sitecustomize.is_file():
+            sitecustomize.touch()
+
+        _ = sitecustomize.write_text(data=sitecustomize_data)
+
+        # Log the result
+        msg = (
+            f"wrote the following to file \n'{sitecustomize}':"
+            f"\n\n{sitecustomize_data}\n"
+        )
+        logger.info(msg)
 
     @computed_field
     @cached_property
@@ -165,8 +222,12 @@ class Mayapy(MayaBaseCommand):
     def cli_cmd(self) -> None:
         """Run mayapy with computed args and env."""
         self.configure_logging()
+        if self.create_prefix_sitecustomize:
+            self.create_sitecustomize()
+            return
+
         args = [self._computed_executable.as_posix(), *self.args]
-        call(
+        _ = call(
             args=args,
             env=self.env,
         )

--- a/src/devin/cli/maya.py
+++ b/src/devin/cli/maya.py
@@ -52,7 +52,7 @@ class MayaBaseCommand(BaseDCCCommand):
     )
     plugin_path: list[DirectoryPath] = Field(
         default_factory=list,
-        description="Extra paths to add to MAYA_PLUGIN_PATH",
+        description="Extra paths to add to MAYA_PLUG_IN_PATH",
     )
     module_path: list[DirectoryPath] = Field(
         default_factory=list,
@@ -71,7 +71,9 @@ class MayaBaseCommand(BaseDCCCommand):
 
         # Set up Maya plugin path
         if self.plugin_path:
-            env["MAYA_PLUGIN_PATH"] = ";".join([x.as_posix() for x in self.plugin_path])
+            env["MAYA_PLUG_IN_PATH"] = ";".join(
+                [x.as_posix() for x in self.plugin_path]
+            )
 
         # Set up Maya module path
         if self.module_path:

--- a/tests/cli/test_maya.py
+++ b/tests/cli/test_maya.py
@@ -135,7 +135,7 @@ def test_maya_paths(
     expected_module_path = ";".join([x.as_posix() for x in module_paths])
     expected_python_path = ";".join([x.as_posix() for x in python_paths])
 
-    assert expected_plugin_path in kwargs["env"]["MAYA_PLUGIN_PATH"]
+    assert expected_plugin_path in kwargs["env"]["MAYA_PLUG_IN_PATH"]
     assert expected_module_path in kwargs["env"]["MAYA_MODULE_PATH"]
     assert expected_python_path in kwargs["env"]["PYTHONPATH"]
 


### PR DESCRIPTION
Add new command to mayapy: --create-prefix-sitecustomize

Creates a sitecustomize.py file in prefix (usually venv) site-packages pointing to the mayapy site-packages directory and the ngSkinTools2 plugin directory.

This enables code discovery of maya and ngSkinTools in IDE without requiring any manual path setup.

Example: 

```shell
# with devin-dcc installed in project venv
devin mayapy -v 2024 --create-prefix-sitecustomize
``` 